### PR TITLE
fix: Get current value when subscribing to configuration service

### DIFF
--- a/src/Darp.Utils.Avalonia/UserControlBase.cs
+++ b/src/Darp.Utils.Avalonia/UserControlBase.cs
@@ -21,7 +21,7 @@ public abstract class UserControlBase<TViewModel> : UserControl
     public virtual TViewModel ViewModel
     {
         get => AvaloniaHelpers.GetViewModel<TViewModel>(base.DataContext);
-        [MemberNotNull(nameof(base.DataContext))]
+        [MemberNotNull(nameof(DataContext))]
         init => DataContext = value;
     }
 }

--- a/src/Darp.Utils.Avalonia/WindowBase.cs
+++ b/src/Darp.Utils.Avalonia/WindowBase.cs
@@ -21,7 +21,7 @@ public abstract class WindowBase<TViewModel> : Window
     public virtual TViewModel ViewModel
     {
         get => AvaloniaHelpers.GetViewModel<TViewModel>(base.DataContext);
-        [MemberNotNull(nameof(base.DataContext))]
+        [MemberNotNull(nameof(DataContext))]
         init => DataContext = value;
     }
 }

--- a/src/Darp.Utils.Configuration/ConfigurationExtensions.cs
+++ b/src/Darp.Utils.Configuration/ConfigurationExtensions.cs
@@ -28,6 +28,7 @@ file sealed class ConfigurationObservable<TConfig, T>(
 
     public IDisposable Subscribe(IObserver<T> observer)
     {
+        _currentValue = _valueSelector(_configurationService.Config);
         PropertyChangedEventHandler handler = GetConfigChangedHandler(observer);
         _configurationService.PropertyChanged += handler;
         return new Disposable(() => _configurationService.PropertyChanged -= handler);

--- a/test/Darp.Utils.Tests.Configuration/ConfigurationServiceTests.cs
+++ b/test/Darp.Utils.Tests.Configuration/ConfigurationServiceTests.cs
@@ -1,5 +1,6 @@
 namespace Darp.Utils.Tests.Configuration;
 
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Json.Serialization;
 using System.Threading;
@@ -180,11 +181,55 @@ public sealed class ConfigurationServiceTests
         service.IsLoaded.Should().BeFalse();
         service.Path.ShouldBe(Path.Join("some/other/path", ConfigFileName));
     }
+
+    [Fact]
+    public async Task Observe_WhenFirstChangeIsEnumDefault_ShouldEmitChangedValue()
+    {
+        // Arrange
+        var assetsService = new MemoryAssetsService(BasePath);
+        var configurationService = new ConfigurationService<TestConfig>(ConfigFileName, assetsService);
+        await configurationService.WriteConfigurationAsync(
+            new TestConfig { LogLevel = TestLogLevel.Warning },
+            CancellationToken.None
+        );
+        var observer = new TestObserver<TestLogLevel>();
+
+        // Act
+        using IDisposable subscription = configurationService.Observe(x => x.LogLevel).Subscribe(observer);
+        await configurationService.WriteConfigurationAsync(
+            new TestConfig { LogLevel = TestLogLevel.Verbose },
+            CancellationToken.None
+        );
+
+        // Assert
+        observer.Values.Should().ContainSingle().Which.Should().Be(TestLogLevel.Verbose);
+        configurationService.Dispose();
+    }
 }
 
 internal sealed record TestConfig
 {
     public string Setting { get; init; } = "Default";
+
+    public TestLogLevel LogLevel { get; init; } = TestLogLevel.Verbose;
+}
+
+internal enum TestLogLevel
+{
+    Verbose = 0,
+    Information = 1,
+    Warning = 2,
+}
+
+internal sealed class TestObserver<T> : IObserver<T>
+{
+    public List<T> Values { get; } = [];
+
+    public void OnCompleted() { }
+
+    public void OnError(Exception error) => throw error;
+
+    public void OnNext(T value) => Values.Add(value);
 }
 
 [JsonSourceGenerationOptions(WriteIndented = true)]


### PR DESCRIPTION
## Summary
When subscribing to a value in the config service, we might miss a notification when we change to the default value. Steps to reproduce:

- Enum with e.g. 3 states, config has enum value "2"
- Subscribe -> _currentValue == default(Enum) == "0"
- Change config entry to "0" -> comparison with "0" -> no event

## Changes
- Get the current value when subscribing

## Testing
Added a regression test

## Checklist
<!-- Additional checks
    - No dead code or debug leftovers
    - Features are properly tested
-->

- [x] PR is scoped and not oversized
- [x] Documentation (and changelog) is updated if needed
- [x] CI Pipeline is successful
- [x] Self-review was done
